### PR TITLE
Added response.Format(request, handlers) for content negotiation

### DIFF
--- a/format.go
+++ b/format.go
@@ -1,0 +1,21 @@
+package response
+
+import "net/http"
+import "bitbucket.org/ww/goautoneg"
+
+func Format(r *http.Request, handlers map[string]func()) {
+	contentTypes := []string{}
+	for k := range handlers {
+		contentTypes = append(contentTypes, k)
+	}
+
+	accept := r.Header.Get("Accept")
+
+	contentType := goautoneg.Negotiate(accept, contentTypes)
+
+	if handler, ok := handlers[contentType]; ok {
+		handler()
+	} else if handler, ok := handlers["default"]; ok {
+		handler()
+	}
+}


### PR DESCRIPTION
Initial PR for #3 which is similar to expressjs `res.format(obj)`

Usage:

``` go
app.Get("/", func (w http.ResponseWriter, r *http.Request) {
    response.Format(r, map[string]func() {
        "text/html": func () {
            w.Header().Set("Content-Type", "text/html")
            fmt.Fprintln(w, "Hello world<br/>")
            fmt.Fprint(w, r.Header.Get("Accept"))
        },
        "application/json": func () {
            response.JSON(w, map[string]string { "hello": "world" })
        },
        "default": func () {
            fmt.Fprintf(w, "default")
        },
    })
})
```

Currently I'm internally using **bitbucket.org/ww/goautoneg** which is a mercurial repository. We should have it hosted in github or embed it in response repository.
